### PR TITLE
Fix -Wpessimizing-move and silence -Wunused-parameter in LLVM headers

### DIFF
--- a/src/llvm-slicer-opts.h
+++ b/src/llvm-slicer-opts.h
@@ -2,7 +2,23 @@
 #define  _DG_TOOLS_LLVM_SLICER_OPTS_H_
 
 #include <vector>
+
+// ignore unused parameters in LLVM libraries
+#if (__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
 #include <llvm/Support/CommandLine.h>
+
+#if (__clang__)
+#pragma clang diagnostic pop // ignore -Wunused-parameter
+#else
+#pragma GCC diagnostic pop
+#endif
 
 #include "dg/llvm/LLVMDependenceGraphBuilder.h"
 

--- a/src/sbt-slicer.cpp
+++ b/src/sbt-slicer.cpp
@@ -904,7 +904,7 @@ bool findSecondarySlicingCriteria(::Slicer& slicer,
 {
     std::set<std::string> recursiveFuns;
     if (slicer.getOptions().dgOptions.cdAlgorithm == dg::CD_ALG::NTSCD) {
-        recursiveFuns = std::move(getRecursiveFuns(slicer));
+        recursiveFuns = getRecursiveFuns(slicer);
     }
 
     // FIXME: do this more efficiently (and use the new DFS class)


### PR DESCRIPTION
Occurs with clang 10 and LLVM 10.