### PR TITLE
Fixes for SV-COMP 2024

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "RelWithDebInfo"
 # --------------------------------------------------
 # Compiler flags
 # --------------------------------------------------
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -36,17 +37,6 @@ message(STATUS "LLVM libraries dir: ${LLVM_LIBRARY_DIRS}")
 
 list(APPEND CMAKE_MODULE_PATH "${LLVM_DIR}")
 include(AddLLVM)
-
-# TODO: move this to the section above when we switch to C++14
-# LLVM 10 and newer require at least C++14 standard
-if (${LLVM_PACKAGE_VERSION} VERSION_GREATER "9.0")
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-else()
-  # otherwise we need C++11 standard
-  set(CMAKE_CXX_STANDARD 11)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-endif()
 
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})

--- a/src/sbt-slicer.cpp
+++ b/src/sbt-slicer.cpp
@@ -182,7 +182,7 @@ bool containsCallTo(const llvm::Module &mod, const std::string &needle) {
 static bool checkUnsupported(dg::LLVMDependenceGraph & dg) {
     std::set<LLVMNode *> cs;
     bool ret = dg.getCallSites(
-	{"pthread_create", "fesetround","longjmp"}, &cs);
+	{"pthread_create", "fesetround", "longjmp"}, &cs);
     llvm::errs() << "Unsupported:\n";
     for (auto *c : cs) {
         llvm::errs() << "  " << *(c->getValue()) << "\n";

--- a/src/sbt-slicer.cpp
+++ b/src/sbt-slicer.cpp
@@ -272,6 +272,12 @@ int main(int argc, char *argv[]) {
         options.cutoffDiverging = false;
     }
 
+    if (options.cutoffDiverging && containsCallTo(*M, "longjmp")) {
+        llvm::errs() << "[sbt-slicer] contains longjmp, not cutting off diverging\n";
+        options.cutoffDiverging = false;
+    }
+
+
     if (options.cutoffDiverging) {
         DBG(sbt - slicer, "Searching for slicing criteria values");
         auto csvalues = getSlicingCriteriaValues(

--- a/src/sbt-slicer.cpp
+++ b/src/sbt-slicer.cpp
@@ -165,6 +165,8 @@ static bool checkUnsupported(dg::LLVMDependenceGraph & /* dg */) {
     std::set<LLVMNode *> cs;
     bool ret = LLVMDependenceGraph::getCallSites(
             {"pthread_create", "fesetround"}, &cs);
+    bool ret = dg.getCallSites(
+	{"pthread_create", "fesetround","longjmp"}, &cs);
     llvm::errs() << "Unsupported:\n";
     for (auto *c : cs) {
         llvm::errs() << "  " << *(c->getValue()) << "\n";


### PR DESCRIPTION
This pull request merges the changes that were used for SV-COMP 2024. Namely, it
- moves the project to C++17
- automatically enables `consider-threads` if the program contains `pthread_create`
- automatically disables `cutoffDiverging` if the program contains `longjmp` (the divergence analysis is not correct in presence of `longjmp`)
- marks `longjmp` as unsupported if it occurs later in the code

The code was used for SV-COMP 2024 and SV-COMP 2025 and was tested there.